### PR TITLE
Left/Right Trigger が正しく入力されない問題を修正

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -152,8 +152,8 @@ void NI_Gamepad::Update()
 		state.leftY = device_->GetLeftThumbStickY();
 		state.rightX = device_->GetRightThumbStickX();
 		state.rightY = device_->GetRightThumbStickY();
-		state.leftTrigger = device_->GetLeftThumbStickX();
-		state.rightTrigger = device_->GetLeftThumbStickX();
+		state.leftTrigger = device_->GetLeftTrigger();
+		state.rightTrigger = device_->GetRightTrigger();
 		state.keyState = device_->GetKeyState();
 		context_.Input( state );
 	}

--- a/src/GamePadDirectInputDevice.cpp
+++ b/src/GamePadDirectInputDevice.cpp
@@ -633,7 +633,7 @@ double CDirectInputDevice::GetAxisValue( long val, int dir )
 }
 double CDirectInputDevice::GetTriggerValue( int num ) const
 {
-	if( num >= DIObj_AxisX || num <= DIObj_Slider_1 ) {
+	if( num >= DIObj_AxisX && num <= DIObj_Slider_1 ) {
 		// 同じ型で並んでいるので配列とみなして処理。スライダーも一緒
 		const LONG	*axis = &(state_.state.lX);
 		LONG	val = axis[num] + (-AXIS_RANGE_MIN);


### PR DESCRIPTION
Gamepad.buttonLeftTriggerCount
Gamepad.buttonRightTriggerCount
が正しく動作しない

- XInput デバイスでは leftThumbStickX に連動した挙動になっている
- DirectInput デバイスではデジタルボタンのLeft/Right Trigger の入力が正しく行われない

という問題が判明／修正しました