### PR TITLE
UNICODEフラグが有効な場合でもビルドできるよう調整

### DIFF
--- a/src/GamePadDeviceInspector.cpp
+++ b/src/GamePadDeviceInspector.cpp
@@ -92,10 +92,15 @@ void CGamePadDeviceInspector::PrintDetail()
 	std::wstringstream mesStream;
 	mesStream << L"Devie Detail :" << std::endl;
 
-	std::string	productName;
 	std::wstring	wproductName;
+#ifdef UNICODE
+	GetProductName( wproductName );
+#else
+	std::string	productName;
 	GetProductName( productName );
-	if( EncodeToUTF16( wproductName, productName ) ) {
+	if( EncodeToUTF16( wproductName, productName ) )
+#endif
+	{
 		mesStream << L"Product Name : " << wproductName << std::endl;
 	}
 	int	main, sub;

--- a/src/GamePadDeviceInspector.h
+++ b/src/GamePadDeviceInspector.h
@@ -47,6 +47,12 @@ class CGamePadDeviceInspector
 	DIDEVICEINSTANCE		device_instance_info_;
 
 public:
+#ifdef UNICODE
+	typedef std::wstring tstring;
+#else
+	typedef std::string tstring;
+#endif
+
 	CGamePadDeviceInspector();
 	bool GetInfomation( IDirectInputDevice8* device );
 
@@ -71,9 +77,9 @@ public:
 	//! 製品の一意な識別子。この識別子は、デバイス メーカーが設定する。 
 	GUID GetProductGuid() const { return device_instance_info_.guidProduct; }
 	//! インスタンスの登録名。たとえば、"Joystick 1"。 
-	void GetInstanceName( std::string& name ) const { name = std::string(device_instance_info_.tszInstanceName); }
+	void GetInstanceName( tstring& name ) const { name = tstring(device_instance_info_.tszInstanceName); }
 	//! 製品の登録名。 
-	void GetProductName( std::string& name ) const { name = std::string(device_instance_info_.tszProductName); }
+	void GetProductName( tstring& name ) const { name = tstring(device_instance_info_.tszProductName); }
 	//! フォース フィードバックに使われるドライバの一意な識別子。ドライバのメーカーがこの識別子を設定する。 
 	GUID GetForceFeedbackDriverGuid() const { return device_instance_info_.guidFFDriver; }
 	//! デバイスが HID (Human Interface Device) デバイスである場合、このメンバには、HID 使用ページ コードが含まれる。 

--- a/src/GamePadDirectInputDevice.cpp
+++ b/src/GamePadDirectInputDevice.cpp
@@ -29,6 +29,7 @@
 補償; または、業務の中断に対する補償を含め)責任をいっさい負いません。
 
 *****************************************************************************/
+#define _USE_MATH_DEFINES 
 
 #include "GamePadDirectInputDevice.h"
 #include "GamePadDirectInputMappingDB.h"
@@ -40,7 +41,6 @@
 #include <vector>
 #include <windows.h>
 
-#define _USE_MATH_DEFINES 
 #include <cmath> 
 
 namespace gamepad {
@@ -65,7 +65,12 @@ bool CDirectInputDevice::EnumObjectsCallback( const DIDEVICEOBJECTINSTANCE* pdid
 
 	// オブジェクト名書き出し
 	std::wstring	objName;
-	if( EncodeToUTF16( objName, std::string(pdidoi->tszName) ) ) {
+#ifdef UNICODE
+	objName = std::wstring(pdidoi->tszName);
+#else
+	if( EncodeToUTF16( objName, std::string(pdidoi->tszName) ) )
+#endif
+	{
 		Log( (std::wstring(L"[ ") + objName + std::wstring(L" ]")).c_str() );
 	}
 
@@ -407,9 +412,13 @@ bool CDirectInputDevice::InitializeDeviceDetail()
 
 	instance_guid_ = inspector_.GetInstanceGuid();
 
+#ifdef UNICODE
+	inspector_.GetProductName( name_ );
+#else
 	std::string name;
 	inspector_.GetProductName( name );
 	EncodeToUTF16( name_, name );
+#endif
 
 	std::wstringstream stream;
 	stream << L"Game Pad Device Name : " << name_;

--- a/src/GamePadInputDevicePort.cpp
+++ b/src/GamePadInputDevicePort.cpp
@@ -225,9 +225,9 @@ void CInputDevicePort::InitializeDirectInput()
 
 	if( dinput_dll_.IsLoaded() == false ) {
 #ifdef _DEBUG
-		dinput_dll_.Load( "dinput8d.dll" );
+		dinput_dll_.Load( _T("dinput8d.dll") );
 #else
-		dinput_dll_.Load( "dinput8.dll" );
+		dinput_dll_.Load( _T("dinput8.dll") );
 #endif
 	}
 

--- a/src/GamePadLog.cpp
+++ b/src/GamePadLog.cpp
@@ -44,6 +44,8 @@
 #define MAX_ERROR_TEXT_LEN 160
 #endif // MAX_ERROR_TEXT_LEN
 
+#include <tchar.h>
+
 namespace gamepad {
 
 struct quartz
@@ -74,7 +76,7 @@ bool quartz::Initialize()
 bool quartz::CheckLoading()
 {
 	if( dll_.IsLoaded() == false ) {
-		dll_.Load( "quartz.dll" );
+		dll_.Load( _T("quartz.dll") );
 	}
 	return dll_.IsLoaded();
 }

--- a/src/GamePadXInputDevice.cpp
+++ b/src/GamePadXInputDevice.cpp
@@ -34,6 +34,7 @@
 
 #include "GamePadXInputDevice.h"
 #include "GamePadDLLLoader.h"
+#include <tchar.h>
 
 namespace gamepad {
 
@@ -97,15 +98,15 @@ bool xinput::Initialize()
 bool xinput::CheckLoading()
 {
 	if( dll_.IsLoaded() == false ) {
-		dll_.Load( "xinput1_3.dll" );
+		dll_.Load( _T("xinput1_3.dll") );
 	}
 // å√Ç¢ÇÃÇ‡ééÇ∑ÅH
 #if 0
 	if( dll_.IsLoaded() == false ) {
-		dll_.Load( "xinput1_2.dll" );
+		dll_.Load( _T("xinput1_2.dll") );
 	}
 	if( dll_.IsLoaded() == false ) {
-		dll_.Load( "xinput1_1.dll" );
+		dll_.Load( _T("xinput1_1.dll") );
 	}
 #endif
 	return dll_.IsLoaded();


### PR DESCRIPTION
UNICODEフラグが有効な時に EncodeToUTF16 を介さずに直接値を取得できるような対応と，
CDLLLoader::Load が LPCTSTR を必要とするので _T(...) で渡すように変更

_USE_MATH_DEFINES の定義が <cmath> インクルード直前にあるとそれ以前のインクルードで <cmath> が読み込まれていた場合に無視されてビルドができなかったので暫定で先頭に移動（このコミットに含めるのは相応しくない場合はカットしてください）

※VCプロジェクトファイルの方にはUNICODEフラグ設定周りの手を入れていません